### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ This is my second hello world git repository.
 
 This is my first edit to the README file. 
 
-Btw, I am following Git's tutorial [here] (https://docs.github.com/en/get-started/quickstart/hello-world) and I am using the [markdown guide] (https://www.markdownguide.org/cheat-sheet/) as a reference to format the text.
+Btw, I am following Git's tutorial [here](https://docs.github.com/en/get-started/quickstart/hello-world) and I am using the [markdown guide](https://www.markdownguide.org/cheat-sheet/) as a reference to format the text.


### PR DESCRIPTION
Remove space between bracketed text and urls in parenthesis to enable hyperlinked text markdown.

The text was not hyperlinked properly because there was a space between the trailing bracket of the text you meant to hyperlink and the leading parenthesis enclosing the url. Removing the space between the two allows the markdown to properly hyperlink the text.

